### PR TITLE
Add user agent for the notebook magic.

### DIFF
--- a/google/generativeai/notebook/magics.py
+++ b/google/generativeai/notebook/magics.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import abc
 
 from google.auth import credentials
+from google.generativeai import client as palm
 from google.generativeai.notebook import gspread_client
 from google.generativeai.notebook import ipython_env
 from google.generativeai.notebook import ipython_env_impl
@@ -31,6 +32,11 @@ from google.generativeai.notebook import sheets_utils
 import IPython
 from IPython.core import magic
 
+
+# Set the UA to distinguish the magic from the client. Do this at import-time
+# so that a user can still call `palm.configure()`, and both their settings
+# and this are honored.
+palm.USER_AGENT = "genai-py-magic"
 
 SheetsInputs = sheets_utils.SheetsInputs
 SheetsOutputs = sheets_utils.SheetsOutputs


### PR DESCRIPTION
This overwrites the client library UA to the same string, but with `-magic`, in order to distinguish the two, but still have the `genai-py` prefix match all client traffic.

It's done during import-time so that it works for both `%load_ext` and `import ...magics`, and so that it still allows a user to call `palm.configure(...)` before using the magic to provide their own client, UA, etc.

Tested with Colab by inspecting `client.default_client_config['client_info'].to_user_agent()`.

Change-Id: I559b669495cf92aaf1c750a527b6bac9c73bd00f