### PR TITLE
Relax the version requirement of google-ai-generativelanguage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ version = get_version()
 release_status = "Development Status :: 7 - Inactive"
 
 dependencies = [
-    "google-ai-generativelanguage==0.6.15",
+    "google-ai-generativelanguage>=0.6.15",
     "google-api-core",
     "google-api-python-client",
     "google-auth>=2.15.0",  # 2.15 adds API key auth support


### PR DESCRIPTION
## Description of the change
<!--- Describe your changes in detail. -->
Relax the version requirement of google-ai-generativelanguage, this is to improve the interoperability with other libraries such as `langchain-google-genai`

## Motivation
<!--- Why is this change required? What problem does it solve? Please include the corresponding issue number/link if applicable. -->
Spotted in https://github.com/langchain-ai/langchain-google/issues/956, the hard coded version would make code that utilizes libraries requiring newer version `google-ai-generativelanguage` stops working.

## Type of change
Choose one: Feature request

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
